### PR TITLE
Add GH action to compile and upload .dat file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tagname:
+        description: Release Tag Name
+        required: true
+        type: string
+
+env:
+  ACEVER: 0.9.34
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    env:
+      ACEFILE: "ace-${{ env.ACEVER }}-x86-64.tar.gz"
+      OUTFILE: "erg-${{ inputs.tagname }}-x86-64-$ACEVER.dat"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tagname }}
+
+      - name: Install ACE
+        run: |
+          wget "http://sweaglesw.org/linguistics/ace/download/$ACEFILE"
+          tar xf "$ACEFILE"
+          ./ace-$ACEVER/ace -V
+
+      - name: Compile Grammar
+        run: |
+          ./ace-$ACEVER/ace -g ace/config.tdl -G "$OUTFILE"
+          bzip2 "$OUTFILE"
+
+      - name: Upload Release Asset
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ inputs.tagname }}" "$OUTFILE".bz2


### PR DESCRIPTION
This adds a GitHub Action script that downloads ACE, compiles the grammar, and uploads the `.dat.bz2` file to a specified release.  You specify the tag name of the release to use, such as `2023`, and it will check out the grammar for that tag and upload to the release of the same tag, assuming the tag and release exist.

Limitations:
- The action is not configured to run automatically (e.g., upon creating a release), and instead it requires a [manual click](https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow). We can easily make it automatic later if it works well enough.
- This only compiles the `.dat` grammar for Linux using [ace-0.9.34](http://sweaglesw.org/linguistics/ace/download/ace-0.9.34-x86-64.tar.gz); it does not compile for Mac or using PET.
- It only compiles the `ace/config.tdl` grammar configuration. Others can be easily added.